### PR TITLE
sort input files (boo#1041090)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ TODO	=	showconsole blogd blogger blogctl isserial libblogger.so
 TODO	+=	blog-store-messages.service blogd.8 blogger.8
 L	:=	libconsole/
 CFLAGS	+=	-I ./ -I ./$(L)
-libfiles := $(wildcard $(L)*.c)
+libfiles := $(sort $(wildcard $(L)*.c))
 
 all: $(TODO)
 


### PR DESCRIPTION
when building packages
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.

https://bugzilla.opensuse.org/show_bug.cgi?id=1041090