### PR TITLE
Getconsoles hardening

### DIFF
--- a/libconsole/console.c
+++ b/libconsole/console.c
@@ -609,6 +609,7 @@ void getconsoles(struct console **cons, int io)
     char fbuf[16], dev[64];
     char *tty = NULL;
     FILE *fc;
+    int items;
 
     if (!cons)
 	error("error: console pointer empty");
@@ -621,10 +622,15 @@ void getconsoles(struct console **cons, int io)
 	goto err;
     }
 
-    while ((fscanf(fc, "%*s %*s (%[^)]) %[0-9:]", &fbuf[0], &dev[0]) == 2)) {
+    while ((items = fscanf(fc, "%*s %*s (%[^)]) %[0-9:]", &fbuf[0], &dev[0]))
+	   != EOF) {
 	char *tmp;
 	int flags, n, maj, min;
 	int ret;
+
+	/* Ignore consoles without tty binding. */
+	if (items != 2)
+	    continue;
 
 	if (!strchr(fbuf, 'E'))
 	    continue;

--- a/libconsole/console.c
+++ b/libconsole/console.c
@@ -662,8 +662,10 @@ err:
     if (!tty)
 	error("can not allocate string");
 
-    if (consalloc(&c, tty, CON_CONSDEV, makedev(TTYAUX_MAJOR, 1), io))
-	*cons = c;
+    if (!consalloc(&c, tty, CON_CONSDEV, makedev(TTYAUX_MAJOR, 1), io))
+	error("/dev/console is not a valid fallback\n");
+
+    *cons = c;
 }
 
 /*

--- a/libconsole/console.c
+++ b/libconsole/console.c
@@ -559,7 +559,7 @@ static int consalloc(struct console **cons, char *name, const int cflags, const 
     insert(&newc->node, head);
 
     if (!io)
-	return 0;
+	return 1;
 
     if ((newc->fd = open(newc->tty, O_WRONLY|O_NONBLOCK|O_NOCTTY)) < 0) {
 	if (errno == EACCES)


### PR DESCRIPTION
Hello Dr. Werner,

showconsole crashed on arm with the following output from /dev/consoles:

$> cat /dev/consoles
pl11                 -W- (E Bp  )
ttyAMA0              -W- (EC p a)  204:64

Please, find several related fixes in this pull request. The first commit is needed to avoid the crash. The last commit is needed to handle the above /dev/consoles output correctly and match the ttyAMA0 console.

Best Regards,
Petr