### PR TITLE
Fixup Makefile for better build system support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,16 @@ endif
 	     SO = echo .so man8/
 
 #
-	MANPATH = /usr/share/man
+	 PREFIX ?= /
+	MANPATH = $(PREFIX)usr/share/man
 	SDOCDIR = $(MANPATH)/man8
-	SBINDIR = /sbin
-	CONFDIR = /etc
-	 LSBDIR = /usr/lib/lsb
-	 LIBDIR = /usr/lib
-	 INCDIR = /usr/include
-      DRACUTMOD = /usr/lib/dracut/modules.d/99blog
-      SYSDUNITS = /usr/lib/systemd/system
+	SBINDIR = $(PREFIX)sbin
+	CONFDIR = $(PREFIX)etc
+	 LSBDIR = $(PREFIX)usr/lib/lsb
+	 LIBDIR = $(PREFIX)usr/lib
+	 INCDIR = $(PREFIX)usr/include
+      DRACUTMOD = $(PREFIX)usr/lib/dracut/modules.d/99blog
+      SYSDUNITS = $(PREFIX)usr/lib/systemd/system
 #
 #
 #

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifeq ($(BLOGGER),1)
 	 CFLAGS += -DBLOGGER
 endif
 	SEDOPTS = s|@@BOOT_LOGFILE@@|$(BOOT_LOGFILE)|;s|@@BOOT_OLDLOGFILE@@|$(BOOT_OLDLOGFILE)|
-	     CC = gcc -g3
+	     CC ?= gcc -g3
 	     RM = rm -f
 	  MKDIR = mkdir -p
 	  RMDIR = rm -rf
@@ -49,8 +49,8 @@ endif
    INSTSCRFLAGS = -c -m 0755
 	INSTSCR = install $(INSTSCRFLAGS)
 	   LINK = ln -sf
-	     AR = ar
-	     LD = ld -shared -O2
+	     AR ?= ar
+	     LD ?= ld -shared -O2
 	    SED = sed -r
 	     SO = echo .so man8/
 


### PR DESCRIPTION
Two main changes:

 * Stop forcibly overriding common compilation tools
 * Use PREFIX for installation location

The first change helps with cross-compilation. The tool name might not be `gcc`, but rather the triplet, followed by the tool name.

The second change adds support for the common PREFIX variable. This is used in Nixpkgs to point to the `/nix/store/.../` output for the derivation (the build).

As they are, those changes should for all intents and purposes, be no-ops when those environment variables are not set.